### PR TITLE
Upgrades commons-collections dependency

### DIFF
--- a/blackboardvc-portlet-webapp/pom.xml
+++ b/blackboardvc-portlet-webapp/pom.xml
@@ -72,6 +72,10 @@
             <artifactId>velocity</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,17 @@
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity</artifactId>
                 <version>1.7</version>
+                <exclusions>
+                  <exclusion>
+                    <groupId>commons-collections</groupId>
+                    <artifactId>commons-collections</artifactId>
+                  </exclusion>
+                </exclusions> 
+            </dependency>
+            <dependency>
+              <groupId>commons-collections</groupId>
+              <artifactId>commons-collections</artifactId>
+              <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Velocity uses commons-collection 3.2.1, so exclude it, add in the latest version.

Tested.
