### PR TITLE
Commons Collections 3.2.1 via dependency management rather than explicit direct dependency

### DIFF
--- a/blackboardvc-portlet-webapp/pom.xml
+++ b/blackboardvc-portlet-webapp/pom.xml
@@ -72,10 +72,6 @@
             <artifactId>velocity</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-collections</groupId>
-            <artifactId>commons-collections</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jasig.resourceserver</groupId>
             <artifactId>resource-server-utils</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,11 @@
                 <scope>provided</scope>
             </dependency>
             <dependency>
+              <groupId>commons-collections</groupId>
+              <artifactId>commons-collections</artifactId>
+              <version>3.2.2</version>
+            </dependency>
+            <dependency>
               <groupId>org.apache.commons</groupId>
 			  <artifactId>commons-lang3</artifactId>
 			  <version>3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -205,17 +205,6 @@
                 <groupId>org.apache.velocity</groupId>
                 <artifactId>velocity</artifactId>
                 <version>1.7</version>
-                <exclusions>
-                  <exclusion>
-                    <groupId>commons-collections</groupId>
-                    <artifactId>commons-collections</artifactId>
-                  </exclusion>
-                </exclusions> 
-            </dependency>
-            <dependency>
-              <groupId>commons-collections</groupId>
-              <artifactId>commons-collections</artifactId>
-              <version>3.2.2</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Alternative solution to #9 , placing `commons-collections` under `dependencyManagement` .

This allows transitive dependencies to mostly do their job, with `commons-collections` pulling into the webapp transitively off of `velocity`.

Hypothetically, if Velocity were to cut a future release that didn't depend on `commons-collections`, and this project were to upgrade to that, then the `commons-collections` dependency would drop out entirely, since it would no longer be pulled in transitively and is not a direct dependency.

In practice, should yield same resulting build.
